### PR TITLE
add: apitoken middleware

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -3,12 +3,13 @@ import authRouter from "./auth/auth.router";
 import tokenRouter from "./token/token.router";
 import userRouter from "./user/user.router";
 import productRouter from "./products/product.router";
+import apiTokenMiddleware from "../middlewares/api-token.middleware";
 
 const apiRouter = Router();
 
 apiRouter.use("/auth", authRouter);
 apiRouter.use("/token", tokenRouter);
 apiRouter.use("/user", userRouter);
-apiRouter.use("/products", productRouter);
+apiRouter.use("/products", apiTokenMiddleware.hasApiToken, productRouter);
 
 export default apiRouter;

--- a/server/services/query-parser.service.ts
+++ b/server/services/query-parser.service.ts
@@ -1,125 +1,131 @@
-import { UrlQuery } from '../types/mongoose/url-query';
+import { UrlQuery } from "../types/mongoose/url-query";
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_ORDER = 1;
 class QueryParserService {
-    getFilters(
-        query: UrlQuery,
-    ):
-        | { email: unknown; $and?: undefined }
-        | { email?: undefined; $and?: undefined }
-        | { $and: { [key: string]: any }[]; email: unknown }
-        | { $and: { [key: string]: any }[]; email?: undefined } {
-        const { email, ...queries } = query;
-        const filtersArray = this.getFiltersArray(queries);
-        if (!filtersArray || filtersArray.length === 0) {
-            if (email) {
-                return { email };
-            }
-            return {};
-        }
-
-        if (email) {
-            return { $and: filtersArray, email };
-        }
-        return { $and: filtersArray };
+  getFilters(
+    query: UrlQuery
+  ):
+    | { email: unknown; $and?: undefined }
+    | { email?: undefined; $and?: undefined }
+    | { $and: { [key: string]: any }[]; email: unknown }
+    | { $and: { [key: string]: any }[]; email?: undefined } {
+    const { email, ...queries } = query;
+    const filtersArray = this.getFiltersArray(queries);
+    if (!filtersArray || filtersArray.length === 0) {
+      if (email) {
+        return { email };
+      }
+      return {};
     }
 
-    private getFiltersArray(query: UrlQuery): { [key: string]: any }[] {
-        return Object.entries(query).reduce((filterQuery, [key, value]) => {
-            if (key.startsWith('_')) {
-                return filterQuery;
-            }
-            return [...filterQuery, this.getFilterQuery(key, value as string)];
-        }, [] as { [key: string]: any }[]);
+    if (email) {
+      return { $and: filtersArray, email };
     }
+    return { $and: filtersArray };
+  }
 
-    private getFilterQuery(key: string, value: string): Record<string, unknown> {
-        const [keyName, operator] = key.split('_');
-        switch (operator) {
-            case 'like':
-                return { [keyName]: { $regex: value, $options: 'i' } };
-            case 'in':
-                return { [keyName]: { [`$in`]: value.split(',') } };
-            case undefined:
-                return { [keyName]: { [`$eq`]: this.parseValue(value) } };
-            default:
-                return {
-                    [keyName]: { [`$${operator}`]: this.parseValue(value) },
-                };
-        }
-    }
+  private getFiltersArray(query: UrlQuery): { [key: string]: any }[] {
+    return Object.entries(query).reduce((filterQuery, [key, value]) => {
+      if (key.startsWith("_")) {
+        return filterQuery;
+      }
+      return [...filterQuery, this.getFilterQuery(key, value as string)];
+    }, [] as { [key: string]: any }[]);
+  }
 
-    private parseValue(value: string): string | boolean | number | null {
-        if (value === 'true') {
-            return true;
-        }
-        if (value === 'false') {
-            return false;
-        }
-        if (/^\d+$/.test(value)) {
-            return parseFloat(value);
-        }
-        if (value === 'null') {
-            return null;
-        }
-
-        return value;
-    }
-
-    getProjection(query: UrlQuery): string {
-        const { _show } = query;
-        if (!_show) {
-            return '';
-        }
-        if (Array.isArray(_show)) {
-            return _show.join(' ');
-        }
-        return _show.split(',').join(' ');
-    }
-
-    getOptions(query: UrlQuery): {
-        sort?: { [x: string]: number } | undefined;
-        limit?: number | undefined;
-        skip?: number | undefined;
-    } {
-        const { _limit, _page, _sort, _order } = query;
+  private getFilterQuery(key: string, value: string): Record<string, unknown> {
+    const [keyName, operator] = key.split("_");
+    switch (operator) {
+      case "like":
+        return { [keyName]: { $regex: value, $options: "i" } };
+      case "in":
+        return { [keyName]: { [`$in`]: value.split(",") } };
+      case undefined:
+        return { [keyName]: { [`$eq`]: this.parseValue(value) } };
+      default:
         return {
-            ...(_page && {
-                skip: parseInt(_page) * (_limit ? parseInt(_limit) : DEFAULT_PAGE_SIZE),
-            }),
-            ...(_limit && { limit: parseInt(_limit) }),
-            ...(_sort && {
-                sort: { [_sort]: _order ? parseInt(_order) : DEFAULT_ORDER },
-            }),
+          [keyName]: { [`$${operator}`]: this.parseValue(value) },
         };
     }
+  }
 
-    getPopulationOptions(query: UrlQuery): string[] | Record<string, string>[] {
-        const { _embed } = query;
-        if (!_embed) {
-            return [];
-        }
-        if (Array.isArray(_embed)) {
-            return _embed.map(path => this.getPopulateOptionPathsObjFromField(path));
-        }
-        const populationOption = _embed.split(',');
-        return populationOption.map(field => this.getPopulateOptionPathsObjFromField(field));
+  private parseValue(value: string): string | boolean | number | null {
+    if (value === "true") {
+      return true;
+    }
+    if (value === "false") {
+      return false;
+    }
+    if (/^\d+$/.test(value)) {
+      return parseFloat(value);
+    }
+    if (value === "null") {
+      return null;
     }
 
-    private getPopulateOptionPathsObjFromField(field: string): { [key: string]: any } {
-        const subFieldStartPos = field.indexOf(':');
-        if (subFieldStartPos === -1) {
-            return { path: field };
-        }
+    return value;
+  }
 
-        const mainPath = field.slice(0, subFieldStartPos);
-        const subPath = field.slice(subFieldStartPos + 1);
-        return {
-            path: mainPath,
-            populate: this.getPopulateOptionPathsObjFromField(subPath),
-        };
+  getProjection(query: UrlQuery): string {
+    const { _show } = query;
+    if (!_show) {
+      return "";
     }
+    if (Array.isArray(_show)) {
+      return _show.join(" ");
+    }
+    return _show.split(",").join(" ");
+  }
+
+  getOptions(query: UrlQuery): {
+    sort?: { [x: string]: number } | undefined;
+    limit?: number | undefined;
+    skip?: number | undefined;
+  } {
+    const { _limit, _page, _sort, _order } = query;
+    return {
+      ...(_page && {
+        skip: parseInt(_page) * (_limit ? parseInt(_limit) : DEFAULT_PAGE_SIZE),
+      }),
+      ...(_limit && { limit: parseInt(_limit) }),
+      ...(_sort && {
+        sort: { [_sort]: _order ? parseInt(_order) : DEFAULT_ORDER },
+      }),
+    };
+  }
+
+  getPopulationOptions(query: UrlQuery): string[] | Record<string, string>[] {
+    const { _embed } = query;
+    if (!_embed) {
+      return [];
+    }
+    if (Array.isArray(_embed)) {
+      return _embed.map((path) =>
+        this.getPopulateOptionPathsObjFromField(path)
+      );
+    }
+    const populationOption = _embed.split(",");
+    return populationOption.map((field) =>
+      this.getPopulateOptionPathsObjFromField(field)
+    );
+  }
+
+  private getPopulateOptionPathsObjFromField(field: string): {
+    [key: string]: any;
+  } {
+    const subFieldStartPos = field.indexOf(":");
+    if (subFieldStartPos === -1) {
+      return { path: field };
+    }
+
+    const mainPath = field.slice(0, subFieldStartPos);
+    const subPath = field.slice(subFieldStartPos + 1);
+    return {
+      path: mainPath,
+      populate: this.getPopulateOptionPathsObjFromField(subPath),
+    };
+  }
 }
 const queryParser = new QueryParserService();
 export default queryParser;


### PR DESCRIPTION
Middleware para controlar el acceso a los tokens. Recordar que este token no es el de la sesión, este es el que se genera en el front. También pueden acceder al mismo consultando en mongodb el apiToken el usuario. Esta primera versión es muy básica y simplemente comprueba si existe un usuario en la base de datos que tenga el token proporcionado. Evidentemente esto no es viable para un producto final, pero no tenemos tiempo para más 🙃.

Para comprobar los endpoints protegidos mediante este middleware (de momento solo /products), poner el token en la cabecera http empleantdo bearer token.